### PR TITLE
Use pointers for optional fields

### DIFF
--- a/cassandra-operator/go.sum
+++ b/cassandra-operator/go.sum
@@ -77,8 +77,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kragniz/licence-compliance-checker v1.0.1-0.20190514150619-bdce557862df h1:GyJp0EJwsE6+tviCqEA+y0LotnAmsu8rMjFcwoaZ3kc=
-github.com/kragniz/licence-compliance-checker v1.0.1-0.20190514150619-bdce557862df/go.mod h1:EOczEhrP2Dj8B+lNnMTX8ak1YF/hUCvBUBiqE0/41IQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747 h1:eQox4Rh4ewJF+mqYPxCkmBAirRnPaHEB26UkNuPyjlk=
@@ -125,7 +123,6 @@ github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.3.0 h1:hI/7Q+DtNZ2kINb6qt/lS+IyXnHQe9e90POfeewL/ME=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
-github.com/sky-uk/licence-compliance-checker v1.0.0/go.mod h1:aV8k9xf/XY+DLnPXQvscJpgHMiB2PTZ4rD2gq1vMK8U=
 github.com/sky-uk/licence-compliance-checker v1.1.0 h1:S3l+chcLXeTk7DoHUR+DNYOTP8k3HEMbkiz1871yl1A=
 github.com/sky-uk/licence-compliance-checker v1.1.0/go.mod h1:aV8k9xf/XY+DLnPXQvscJpgHMiB2PTZ4rD2gq1vMK8U=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers/cassandra.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers/cassandra.go
@@ -27,3 +27,10 @@ func GetBootstrapperImage(c *v1alpha1.Cassandra) string {
 	}
 	return v1alpha1.DefaultCassandraBootstrapperImage
 }
+
+func GetDatacenter(c *v1alpha1.Cassandra) string {
+	if c.Spec.Datacenter == nil {
+		return v1alpha1.DefaultDCName
+	}
+	return *c.Spec.Datacenter
+}

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers/cassandra.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers/cassandra.go
@@ -28,6 +28,16 @@ func GetBootstrapperImage(c *v1alpha1.Cassandra) string {
 	return v1alpha1.DefaultCassandraBootstrapperImage
 }
 
+// GetSnapshopImage returns the snapshot image for a cluster
+func GetSnapshopImage(c *v1alpha1.Cassandra) string {
+	if c.Spec.Snapshot != nil {
+		if c.Spec.Snapshot.Image != nil {
+			return *c.Spec.Snapshot.Image
+		}
+	}
+	return v1alpha1.DefaultCassandraSnapshotImage
+}
+
 func GetDatacenter(c *v1alpha1.Cassandra) string {
 	if c.Spec.Datacenter == nil {
 		return v1alpha1.DefaultDCName

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers/cassandra.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers/cassandra.go
@@ -12,6 +12,14 @@ func UseEmptyDir(c *v1alpha1.Cassandra) bool {
 	return false
 }
 
+// GetImage returns the image for a cluster
+func GetCassandraImage(c *v1alpha1.Cassandra) string {
+	if c.Spec.Pod.Image != nil {
+		return *c.Spec.Pod.Image
+	}
+	return v1alpha1.DefaultCassandraImage
+}
+
 // GetBootstrapperImage returns the bootstrapper image for a cluster
 func GetBootstrapperImage(c *v1alpha1.Cassandra) string {
 	if c.Spec.Pod.BootstrapperImage != nil {

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers/cassandra.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers/cassandra.go
@@ -1,0 +1,13 @@
+package helpers
+
+import (
+	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1"
+)
+
+// UseEmptyDir returns a dereferenced value for Spec.UseEmptyDir
+func UseEmptyDir(c *v1alpha1.Cassandra) bool {
+	if c.Spec.UseEmptyDir != nil {
+		return *c.Spec.UseEmptyDir
+	}
+	return false
+}

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers/cassandra.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers/cassandra.go
@@ -11,3 +11,11 @@ func UseEmptyDir(c *v1alpha1.Cassandra) bool {
 	}
 	return false
 }
+
+// GetBootstrapperImage returns the bootstrapper image for a cluster
+func GetBootstrapperImage(c *v1alpha1.Cassandra) string {
+	if c.Spec.Pod.BootstrapperImage != nil {
+		return *c.Spec.Pod.BootstrapperImage
+	}
+	return v1alpha1.DefaultCassandraBootstrapperImage
+}

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
@@ -36,8 +36,8 @@ type CassandraSpec struct {
 	Datacenter *string `json:"datacenter,omitempty"`
 	Racks      []Rack  `json:"racks"`
 	// +optional
-	UseEmptyDir bool `json:"useEmptyDir"`
-	Pod         Pod  `json:"pod"`
+	UseEmptyDir *bool `json:"useEmptyDir,omitempty"`
+	Pod         Pod   `json:"pod"`
 	// +optional
 	Snapshot *Snapshot `json:"snapshot,omitempty"`
 }

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
@@ -14,8 +14,12 @@ import (
 const (
 	NodeServiceAccountName     = "cassandra-node"
 	SnapshotServiceAccountName = "cassandra-snapshot"
+
 	// DefaultDCName is the default data center name which each Cassandra pod belongs to
 	DefaultDCName = "dc1"
+
+	// DefaultCassandraBootstrapperImage is the name of the Docker image used to prepare the configuration for the Cassandra node before it can be started
+	DefaultCassandraBootstrapperImage = "skyuk/cassandra-bootstrapper:latest"
 )
 
 // +genclient
@@ -57,7 +61,7 @@ type Probe struct {
 
 type Pod struct {
 	// +optional
-	BootstrapperImage string `json:"bootstrapperImage"`
+	BootstrapperImage *string `json:"bootstrapperImage,omitempty"`
 	// +optional
 	Image       string            `json:"image"`
 	StorageSize resource.Quantity `json:"storageSize"`

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
@@ -162,14 +162,6 @@ func (c *Cassandra) CustomConfigMapName() string {
 	return fmt.Sprintf("%s-config", c.Name)
 }
 
-// TODO: Move this to Cassandra top-level object
-func (c *CassandraSpec) GetDatacenter() string {
-	if c.Datacenter == nil {
-		return DefaultDCName
-	}
-	return *c.Datacenter
-}
-
 // SnapshotPropertiesUpdated returns false when snapshot1 and snapshot2 have the same properties disregarding retention policy
 func SnapshotPropertiesUpdated(snapshot1 *Snapshot, snapshot2 *Snapshot) bool {
 	return snapshot1.Schedule != snapshot2.Schedule ||

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
@@ -20,6 +20,9 @@ const (
 
 	// DefaultCassandraBootstrapperImage is the name of the Docker image used to prepare the configuration for the Cassandra node before it can be started
 	DefaultCassandraBootstrapperImage = "skyuk/cassandra-bootstrapper:latest"
+
+	// DefaultCassandraImage is the name of the default Docker image used on Cassandra pods
+	DefaultCassandraImage = "cassandra:3.11"
 )
 
 // +genclient
@@ -63,7 +66,7 @@ type Pod struct {
 	// +optional
 	BootstrapperImage *string `json:"bootstrapperImage,omitempty"`
 	// +optional
-	Image       string            `json:"image"`
+	Image       *string           `json:"image"`
 	StorageSize resource.Quantity `json:"storageSize"`
 	Memory      resource.Quantity `json:"memory"`
 	CPU         resource.Quantity `json:"cpu"`

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
@@ -66,7 +66,7 @@ type Pod struct {
 	// +optional
 	BootstrapperImage *string `json:"bootstrapperImage,omitempty"`
 	// +optional
-	Image       *string           `json:"image"`
+	Image       *string           `json:"image,omitempty"`
 	StorageSize resource.Quantity `json:"storageSize"`
 	Memory      resource.Quantity `json:"memory"`
 	CPU         resource.Quantity `json:"cpu"`

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/types.go
@@ -18,11 +18,14 @@ const (
 	// DefaultDCName is the default data center name which each Cassandra pod belongs to
 	DefaultDCName = "dc1"
 
+	// DefaultCassandraImage is the name of the default Docker image used on Cassandra pods
+	DefaultCassandraImage = "cassandra:3.11"
+
 	// DefaultCassandraBootstrapperImage is the name of the Docker image used to prepare the configuration for the Cassandra node before it can be started
 	DefaultCassandraBootstrapperImage = "skyuk/cassandra-bootstrapper:latest"
 
-	// DefaultCassandraImage is the name of the default Docker image used on Cassandra pods
-	DefaultCassandraImage = "cassandra:3.11"
+	// DefaultCassandraSnapshotImage is the name of the Docker image used to make and cleanup snapshots
+	DefaultCassandraSnapshotImage = "skyuk/cassandra-snapshot:latest"
 )
 
 // +genclient
@@ -100,7 +103,7 @@ type Rack struct {
 // Snapshot defines the snapshot creation and deletion configuration
 type Snapshot struct {
 	// +optional
-	Image string `json:"image"`
+	Image *string `json:"image,omitempty"`
 	// Schedule follows the cron format, see https://en.wikipedia.org/wiki/Cron
 	Schedule string `json:"schedule"`
 	// +optional

--- a/cassandra-operator/pkg/cluster/cluster.go
+++ b/cassandra-operator/pkg/cluster/cluster.go
@@ -543,7 +543,7 @@ func (c *Cluster) createEnvironmentVariableDefinition(rack *v1alpha1.Rack) []v1.
 		},
 		{
 			Name:  "CLUSTER_DATA_CENTER",
-			Value: c.definition.Spec.GetDatacenter(),
+			Value: v1alpha1helpers.GetDatacenter(c.definition),
 		},
 		{
 			Name: "NODE_LISTEN_ADDRESS",

--- a/cassandra-operator/pkg/cluster/cluster_test.go
+++ b/cassandra-operator/pkg/cluster/cluster_test.go
@@ -75,14 +75,14 @@ var _ = Describe("cluster construction", func() {
 		It("should use the 3.11 version of the apache cassandra image if one is not supplied for the cluster", func() {
 			cluster, err := ACluster(clusterDef)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(cluster.definition.Spec.Pod.Image).To(Equal("cassandra:3.11"))
+			Expect(*cluster.definition.Spec.Pod.Image).To(Equal("cassandra:3.11"))
 		})
 
 		It("should use the specified version of the cassandra image if one is given", func() {
 			clusterDef.Spec.Pod.Image = ptr.String("somerepo/someimage:v1.0")
 			cluster, err := ACluster(clusterDef)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(cluster.definition.Spec.Pod.Image).To(Equal("somerepo/someimage:v1.0"))
+			Expect(*cluster.definition.Spec.Pod.Image).To(Equal("somerepo/someimage:v1.0"))
 		})
 
 		It("should use the latest version of the cassandra bootstrapper image if one is not supplied for the cluster", func() {
@@ -363,14 +363,15 @@ var _ = Describe("cluster construction", func() {
 			It("should use the latest version of the cassandra snapshot image if one is not supplied for the cluster", func() {
 				cluster, err := ACluster(clusterDef)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.definition.Spec.Snapshot.Image).To(Equal("skyuk/cassandra-snapshot:latest"))
+				Expect(*cluster.definition.Spec.Snapshot.Image).To(Equal("skyuk/cassandra-snapshot:latest"))
 			})
 
 			It("should use the specified version of the cassandra snapshot image if one is given", func() {
-				clusterDef.Spec.Snapshot.Image = "somerepo/some-snapshot-image:v1.0"
+				img := "somerepo/some-snapshot-image:v1.0"
+				clusterDef.Spec.Snapshot.Image = &img
 				cluster, err := ACluster(clusterDef)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.definition.Spec.Snapshot.Image).To(Equal("somerepo/some-snapshot-image:v1.0"))
+				Expect(*cluster.definition.Spec.Snapshot.Image).To(Equal("somerepo/some-snapshot-image:v1.0"))
 			})
 
 		})
@@ -448,7 +449,7 @@ var _ = Describe("creation of stateful sets", func() {
 		Expect(statefulSet.Spec.Template.Spec.InitContainers).To(HaveLen(2))
 
 		Expect(statefulSet.Spec.Template.Spec.InitContainers[0].Name).To(Equal("init-config"))
-		Expect(statefulSet.Spec.Template.Spec.InitContainers[0].Image).To(Equal(cluster.definition.Spec.Pod.Image))
+		Expect(statefulSet.Spec.Template.Spec.InitContainers[0].Image).To(Equal(*cluster.definition.Spec.Pod.Image))
 		Expect(statefulSet.Spec.Template.Spec.InitContainers[0].Command).To(Equal([]string{"sh", "-c", "cp -vr /etc/cassandra/* /configuration"}))
 		Expect(*statefulSet.Spec.Template.Spec.InitContainers[0].Resources.Requests.Memory()).To(Equal(clusterDef.Spec.Pod.Memory))
 		Expect(*statefulSet.Spec.Template.Spec.InitContainers[0].Resources.Requests.Cpu()).To(Equal(clusterDef.Spec.Pod.CPU))
@@ -841,7 +842,8 @@ var _ = Describe("creation of snapshot job", func() {
 	})
 
 	It("should create a cronjob which pod is using the specified snapshot image", func() {
-		clusterDef.Spec.Snapshot.Image = "somerepo/snapshot:v1"
+		img := "somerepo/snapshot:v1"
+		clusterDef.Spec.Snapshot.Image = &img
 		cluster, err := ACluster(clusterDef)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -980,7 +982,8 @@ var _ = Describe("creation of snapshot cleanup job", func() {
 	})
 
 	It("should create a cronjob which pod is using the specified snapshot image", func() {
-		clusterDef.Spec.Snapshot.Image = "somerepo/snapshot:v1"
+		img := "somerepo/snapshot:v1"
+		clusterDef.Spec.Snapshot.Image = &img
 		cluster, err := ACluster(clusterDef)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/cassandra-operator/pkg/cluster/cluster_test.go
+++ b/cassandra-operator/pkg/cluster/cluster_test.go
@@ -79,7 +79,7 @@ var _ = Describe("cluster construction", func() {
 		})
 
 		It("should use the specified version of the cassandra image if one is given", func() {
-			clusterDef.Spec.Pod.Image = "somerepo/someimage:v1.0"
+			clusterDef.Spec.Pod.Image = ptr.String("somerepo/someimage:v1.0")
 			cluster, err := ACluster(clusterDef)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cluster.definition.Spec.Pod.Image).To(Equal("somerepo/someimage:v1.0"))

--- a/cassandra-operator/pkg/cluster/cluster_test.go
+++ b/cassandra-operator/pkg/cluster/cluster_test.go
@@ -6,6 +6,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1"
+	v1alpha1helpers "github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers"
+	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/util/ptr"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/test"
 	"k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
@@ -268,7 +270,7 @@ var _ = Describe("cluster construction", func() {
 
 		Context("useEmptyDir is true", func() {
 			BeforeEach(func() {
-				clusterDef.Spec.UseEmptyDir = true
+				clusterDef.Spec.UseEmptyDir = ptr.Bool(true)
 			})
 
 			It("should accept a configuration with no pod storage", func() {
@@ -287,13 +289,13 @@ var _ = Describe("cluster construction", func() {
 				clusterDef.Spec.Pod.StorageSize = resource.Quantity{}
 				cluster, err := ACluster(clusterDef)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.definition.Spec.UseEmptyDir).To(BeTrue())
+				Expect(v1alpha1helpers.UseEmptyDir(cluster.definition)).To(BeTrue())
 			})
 		})
 
 		Context("useEmptyDir is false", func() {
 			BeforeEach(func() {
-				clusterDef.Spec.UseEmptyDir = false
+				clusterDef.Spec.UseEmptyDir = ptr.Bool(false)
 			})
 
 			It("should reject a configuration with no pod storage size property", func() {
@@ -521,7 +523,7 @@ var _ = Describe("creation of stateful sets", func() {
 
 	It("should mount an emptyDir into the main container if useEmptyDir is set", func() {
 		// given
-		clusterDef.Spec.UseEmptyDir = true
+		clusterDef.Spec.UseEmptyDir = ptr.Bool(true)
 		clusterDef.Spec.Pod.StorageSize = resource.MustParse("0")
 		cluster, err := ACluster(clusterDef)
 		Expect(err).ToNot(HaveOccurred())

--- a/cassandra-operator/pkg/cluster/cluster_test.go
+++ b/cassandra-operator/pkg/cluster/cluster_test.go
@@ -88,14 +88,14 @@ var _ = Describe("cluster construction", func() {
 		It("should use the latest version of the cassandra bootstrapper image if one is not supplied for the cluster", func() {
 			cluster, err := ACluster(clusterDef)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(cluster.definition.Spec.Pod.BootstrapperImage).To(Equal("skyuk/cassandra-bootstrapper:latest"))
+			Expect(*cluster.definition.Spec.Pod.BootstrapperImage).To(Equal("skyuk/cassandra-bootstrapper:latest"))
 		})
 
 		It("should use the specified version of the cassandra bootstrapper image if one is given", func() {
-			clusterDef.Spec.Pod.BootstrapperImage = "somerepo/some-bootstrapper-image:v1.0"
+			clusterDef.Spec.Pod.BootstrapperImage = ptr.String("somerepo/some-bootstrapper-image:v1.0")
 			cluster, err := ACluster(clusterDef)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(cluster.definition.Spec.Pod.BootstrapperImage).To(Equal("somerepo/some-bootstrapper-image:v1.0"))
+			Expect(*cluster.definition.Spec.Pod.BootstrapperImage).To(Equal("somerepo/some-bootstrapper-image:v1.0"))
 		})
 
 		It("should set the default liveness probe values if it is not configured for the cluster", func() {
@@ -462,7 +462,7 @@ var _ = Describe("creation of stateful sets", func() {
 	})
 
 	It("should create the bootstrapper init container with the specified image if one is given", func() {
-		clusterDef.Spec.Pod.BootstrapperImage = "somerepo/abootstapperimage:v1"
+		clusterDef.Spec.Pod.BootstrapperImage = ptr.String("somerepo/abootstapperimage:v1")
 		cluster, err := ACluster(clusterDef)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/cassandra-operator/pkg/operator/operations/adjuster/adjuster.go
+++ b/cassandra-operator/pkg/operator/operations/adjuster/adjuster.go
@@ -191,7 +191,11 @@ func (r *Adjuster) ensureChangeIsAllowed(oldCluster, newCluster *v1alpha1.Cassan
 		return fmt.Errorf("changing image is forbidden. The image used will continue to be '%v'", currentImage)
 	}
 	if !reflect.DeepEqual(oldCluster.UseEmptyDir, newCluster.UseEmptyDir) {
-		return fmt.Errorf("changing useEmptyDir is forbidden. The useEmptyDir used will continue to be '%v'", oldCluster.UseEmptyDir)
+		useEmptyDir := false
+		if oldCluster.UseEmptyDir != nil {
+			useEmptyDir = *oldCluster.UseEmptyDir
+		}
+		return fmt.Errorf("changing useEmptyDir is forbidden. The useEmptyDir used will continue to be '%v'", useEmptyDir)
 	}
 
 	for _, matchedRack := range matchedRacks {

--- a/cassandra-operator/pkg/operator/operations/adjuster/adjuster.go
+++ b/cassandra-operator/pkg/operator/operations/adjuster/adjuster.go
@@ -119,7 +119,7 @@ func New() (*Adjuster, error) {
 // be applied in order for the running cluster to be in the state matching newCluster.
 func (r *Adjuster) ChangesForCluster(oldCluster *v1alpha1.Cassandra, newCluster *v1alpha1.Cassandra) ([]ClusterChange, error) {
 	addedRacks, matchedRacks, deletedRacks := r.matchRacks(&oldCluster.Spec, &newCluster.Spec)
-	if err := r.ensureChangeIsAllowed(&oldCluster.Spec, &newCluster.Spec, matchedRacks); err != nil {
+	if err := r.ensureChangeIsAllowed(oldCluster, newCluster, matchedRacks); err != nil {
 		return nil, err
 	}
 
@@ -179,24 +179,17 @@ func (r *Adjuster) scaleDownPatchForRack(nodesToScaleDown int) string {
 	return fmt.Sprintf(scaleDownPatchTemplate, nodesToScaleDown)
 }
 
-func (r *Adjuster) ensureChangeIsAllowed(oldCluster, newCluster *v1alpha1.CassandraSpec, matchedRacks []matchedRack) error {
-	if oldCluster.GetDatacenter() != newCluster.GetDatacenter() {
-		return fmt.Errorf("changing dc is forbidden. The dc used will continue to be '%v'", oldCluster.GetDatacenter())
+func (r *Adjuster) ensureChangeIsAllowed(oldCluster, newCluster *v1alpha1.Cassandra, matchedRacks []matchedRack) error {
+	if oldCluster.Spec.GetDatacenter() != newCluster.Spec.GetDatacenter() {
+		return fmt.Errorf("changing dc is forbidden. The dc used will continue to be '%v'", oldCluster.Spec.GetDatacenter())
 	}
 
-	if !reflect.DeepEqual(oldCluster.Pod.Image, newCluster.Pod.Image) {
-		currentImage := oldCluster.Pod.Image
-		if currentImage == "" {
-			currentImage = cluster.DefaultCassandraImage
-		}
+	if !reflect.DeepEqual(oldCluster.Spec.Pod.Image, newCluster.Spec.Pod.Image) {
+		currentImage := v1alpha1helpers.GetCassandraImage(oldCluster)
 		return fmt.Errorf("changing image is forbidden. The image used will continue to be '%v'", currentImage)
 	}
-	if !reflect.DeepEqual(oldCluster.UseEmptyDir, newCluster.UseEmptyDir) {
-		useEmptyDir := false
-		if oldCluster.UseEmptyDir != nil {
-			useEmptyDir = *oldCluster.UseEmptyDir
-		}
-		return fmt.Errorf("changing useEmptyDir is forbidden. The useEmptyDir used will continue to be '%v'", useEmptyDir)
+	if !reflect.DeepEqual(oldCluster.Spec.UseEmptyDir, newCluster.Spec.UseEmptyDir) {
+		return fmt.Errorf("changing useEmptyDir is forbidden. The useEmptyDir used will continue to be '%v'", v1alpha1helpers.UseEmptyDir(oldCluster))
 	}
 
 	for _, matchedRack := range matchedRacks {

--- a/cassandra-operator/pkg/operator/operations/adjuster/adjuster.go
+++ b/cassandra-operator/pkg/operator/operations/adjuster/adjuster.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1"
+	v1alpha1helpers "github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/cluster"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/operator/hash"
 	"k8s.io/api/core/v1"
@@ -116,9 +117,9 @@ func New() (*Adjuster, error) {
 
 // ChangesForCluster compares oldCluster with newCluster, and produces an ordered list of ClusterChanges which need to
 // be applied in order for the running cluster to be in the state matching newCluster.
-func (r *Adjuster) ChangesForCluster(oldCluster *v1alpha1.CassandraSpec, newCluster *v1alpha1.CassandraSpec) ([]ClusterChange, error) {
-	addedRacks, matchedRacks, deletedRacks := r.matchRacks(oldCluster, newCluster)
-	if err := r.ensureChangeIsAllowed(oldCluster, newCluster, matchedRacks); err != nil {
+func (r *Adjuster) ChangesForCluster(oldCluster *v1alpha1.Cassandra, newCluster *v1alpha1.Cassandra) ([]ClusterChange, error) {
+	addedRacks, matchedRacks, deletedRacks := r.matchRacks(&oldCluster.Spec, &newCluster.Spec)
+	if err := r.ensureChangeIsAllowed(&oldCluster.Spec, &newCluster.Spec, matchedRacks); err != nil {
 		return nil, err
 	}
 
@@ -159,14 +160,14 @@ func (r *Adjuster) CreateConfigMapHashPatchForRack(rack *v1alpha1.Rack, configMa
 	return &ClusterChange{Rack: *rack, ChangeType: UpdateRack, Patch: patch}
 }
 
-func (r *Adjuster) patchForRack(rack *v1alpha1.Rack, newCluster *v1alpha1.CassandraSpec, changeTime time.Time) string {
+func (r *Adjuster) patchForRack(rack *v1alpha1.Rack, newCluster *v1alpha1.Cassandra, changeTime time.Time) string {
 	props := patchProperties{
 		Replicas:             rack.Replicas,
-		PodBootstrapperImage: newCluster.Pod.BootstrapperImage,
-		PodCPU:               newCluster.Pod.CPU.String(),
-		PodMemory:            newCluster.Pod.Memory.String(),
-		PodLivenessProbe:     newCluster.Pod.LivenessProbe,
-		PodReadinessProbe:    newCluster.Pod.ReadinessProbe,
+		PodBootstrapperImage: v1alpha1helpers.GetBootstrapperImage(newCluster),
+		PodCPU:               newCluster.Spec.Pod.CPU.String(),
+		PodMemory:            newCluster.Spec.Pod.Memory.String(),
+		PodLivenessProbe:     newCluster.Spec.Pod.LivenessProbe,
+		PodReadinessProbe:    newCluster.Spec.Pod.ReadinessProbe,
 	}
 	var patch bytes.Buffer
 	r.patchTemplate.Execute(&patch, props)
@@ -210,12 +211,12 @@ func (r *Adjuster) ensureChangeIsAllowed(oldCluster, newCluster *v1alpha1.Cassan
 	return nil
 }
 
-func (r *Adjuster) podSpecHasChanged(oldCluster, newCluster *v1alpha1.CassandraSpec) bool {
-	return !reflect.DeepEqual(oldCluster.Pod.CPU, newCluster.Pod.CPU) ||
-		!reflect.DeepEqual(oldCluster.Pod.Memory, newCluster.Pod.Memory) ||
-		!reflect.DeepEqual(oldCluster.Pod.LivenessProbe, newCluster.Pod.LivenessProbe) ||
-		!reflect.DeepEqual(oldCluster.Pod.ReadinessProbe, newCluster.Pod.ReadinessProbe) ||
-		!reflect.DeepEqual(oldCluster.Pod.BootstrapperImage, newCluster.Pod.BootstrapperImage)
+func (r *Adjuster) podSpecHasChanged(oldCluster, newCluster *v1alpha1.Cassandra) bool {
+	return !reflect.DeepEqual(oldCluster.Spec.Pod.CPU, newCluster.Spec.Pod.CPU) ||
+		!reflect.DeepEqual(oldCluster.Spec.Pod.Memory, newCluster.Spec.Pod.Memory) ||
+		!reflect.DeepEqual(oldCluster.Spec.Pod.LivenessProbe, newCluster.Spec.Pod.LivenessProbe) ||
+		!reflect.DeepEqual(oldCluster.Spec.Pod.ReadinessProbe, newCluster.Spec.Pod.ReadinessProbe) ||
+		!reflect.DeepEqual(oldCluster.Spec.Pod.BootstrapperImage, newCluster.Spec.Pod.BootstrapperImage)
 }
 
 func (r *Adjuster) scaledUpRacks(matchedRacks []matchedRack) []v1alpha1.Rack {

--- a/cassandra-operator/pkg/operator/operations/adjuster/adjuster.go
+++ b/cassandra-operator/pkg/operator/operations/adjuster/adjuster.go
@@ -180,8 +180,8 @@ func (r *Adjuster) scaleDownPatchForRack(nodesToScaleDown int) string {
 }
 
 func (r *Adjuster) ensureChangeIsAllowed(oldCluster, newCluster *v1alpha1.Cassandra, matchedRacks []matchedRack) error {
-	if oldCluster.Spec.GetDatacenter() != newCluster.Spec.GetDatacenter() {
-		return fmt.Errorf("changing dc is forbidden. The dc used will continue to be '%v'", oldCluster.Spec.GetDatacenter())
+	if v1alpha1helpers.GetDatacenter(oldCluster) != v1alpha1helpers.GetDatacenter(newCluster) {
+		return fmt.Errorf("changing dc is forbidden. The dc used will continue to be '%v'", v1alpha1helpers.GetDatacenter(oldCluster))
 	}
 
 	if !reflect.DeepEqual(oldCluster.Spec.Pod.Image, newCluster.Spec.Pod.Image) {

--- a/cassandra-operator/pkg/operator/operations/adjuster/adjuster_test.go
+++ b/cassandra-operator/pkg/operator/operations/adjuster/adjuster_test.go
@@ -43,8 +43,8 @@ func TestCluster(t *testing.T) {
 }
 
 var _ = Describe("cluster events", func() {
-	var oldClusterSpec *v1alpha1.CassandraSpec
-	var newClusterSpec *v1alpha1.CassandraSpec
+	var oldCluster *v1alpha1.Cassandra
+	var newCluster *v1alpha1.Cassandra
 	var adjuster *Adjuster
 
 	BeforeEach(func() {
@@ -62,28 +62,32 @@ var _ = Describe("cluster events", func() {
 			SuccessThreshold:    int32(1),
 			TimeoutSeconds:      int32(5),
 		}
-		oldClusterSpec = &v1alpha1.CassandraSpec{
-			Datacenter: ptr.String("ADatacenter"),
-			Racks:      []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}},
-			Pod: v1alpha1.Pod{
-				Image:          "anImage",
-				Memory:         resource.MustParse("2Gi"),
-				CPU:            resource.MustParse("100m"),
-				StorageSize:    resource.MustParse("1Gi"),
-				LivenessProbe:  livenessProbe.DeepCopy(),
-				ReadinessProbe: readinessProbe.DeepCopy(),
+		oldCluster = &v1alpha1.Cassandra{
+			Spec: v1alpha1.CassandraSpec{
+				Datacenter: ptr.String("ADatacenter"),
+				Racks:      []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}},
+				Pod: v1alpha1.Pod{
+					Image:          "anImage",
+					Memory:         resource.MustParse("2Gi"),
+					CPU:            resource.MustParse("100m"),
+					StorageSize:    resource.MustParse("1Gi"),
+					LivenessProbe:  livenessProbe.DeepCopy(),
+					ReadinessProbe: readinessProbe.DeepCopy(),
+				},
 			},
 		}
-		newClusterSpec = &v1alpha1.CassandraSpec{
-			Datacenter: ptr.String("ADatacenter"),
-			Racks:      []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}},
-			Pod: v1alpha1.Pod{
-				Image:          "anImage",
-				Memory:         resource.MustParse("2Gi"),
-				CPU:            resource.MustParse("100m"),
-				StorageSize:    resource.MustParse("1Gi"),
-				LivenessProbe:  livenessProbe.DeepCopy(),
-				ReadinessProbe: readinessProbe.DeepCopy(),
+		newCluster = &v1alpha1.Cassandra{
+			Spec: v1alpha1.CassandraSpec{
+				Datacenter: ptr.String("ADatacenter"),
+				Racks:      []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}},
+				Pod: v1alpha1.Pod{
+					Image:          "anImage",
+					Memory:         resource.MustParse("2Gi"),
+					CPU:            resource.MustParse("100m"),
+					StorageSize:    resource.MustParse("1Gi"),
+					LivenessProbe:  livenessProbe.DeepCopy(),
+					ReadinessProbe: readinessProbe.DeepCopy(),
+				},
 			},
 		}
 		var err error
@@ -109,33 +113,33 @@ var _ = Describe("cluster events", func() {
 
 	Context("pod spec change is detected", func() {
 		It("should produce a change with updated cpu when cpu specification has changed", func() {
-			newClusterSpec.Pod.CPU = resource.MustParse("110m")
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			newCluster.Spec.Pod.CPU = resource.MustParse("110m")
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(1))
-			Expect(changes).To(HaveClusterChange(newClusterSpec.Racks[0], UpdateRack, map[string]interface{}{containerCPU: "110m"}, 0))
+			Expect(changes).To(HaveClusterChange(newCluster.Spec.Racks[0], UpdateRack, map[string]interface{}{containerCPU: "110m"}, 0))
 		})
 
 		It("should produce a change with updated memory when memory specification has changed", func() {
-			newClusterSpec.Pod.Memory = resource.MustParse("1Gi")
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			newCluster.Spec.Pod.Memory = resource.MustParse("1Gi")
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(1))
-			Expect(changes).To(HaveClusterChange(newClusterSpec.Racks[0], UpdateRack, map[string]interface{}{containerMemoryRequest: "1Gi", containerMemoryLimit: "1Gi"}, 0))
+			Expect(changes).To(HaveClusterChange(newCluster.Spec.Racks[0], UpdateRack, map[string]interface{}{containerMemoryRequest: "1Gi", containerMemoryLimit: "1Gi"}, 0))
 		})
 
 		It("should produce a change with updated timeout when liveness probe specification has changed", func() {
-			newClusterSpec.Pod.LivenessProbe.FailureThreshold = 5
-			newClusterSpec.Pod.LivenessProbe.InitialDelaySeconds = 99
-			newClusterSpec.Pod.LivenessProbe.PeriodSeconds = 20
-			newClusterSpec.Pod.LivenessProbe.TimeoutSeconds = 10
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			newCluster.Spec.Pod.LivenessProbe.FailureThreshold = 5
+			newCluster.Spec.Pod.LivenessProbe.InitialDelaySeconds = 99
+			newCluster.Spec.Pod.LivenessProbe.PeriodSeconds = 20
+			newCluster.Spec.Pod.LivenessProbe.TimeoutSeconds = 10
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(1))
-			Expect(changes).To(HaveClusterChange(newClusterSpec.Racks[0],
+			Expect(changes).To(HaveClusterChange(newCluster.Spec.Racks[0],
 				UpdateRack,
 				map[string]interface{}{
 					livenessProbeFailureThreshold:    float64(5),
@@ -147,16 +151,16 @@ var _ = Describe("cluster events", func() {
 		})
 
 		It("should produce a change with updated timeout when readiness probe specification has changed", func() {
-			newClusterSpec.Pod.ReadinessProbe.FailureThreshold = 27
-			newClusterSpec.Pod.ReadinessProbe.InitialDelaySeconds = 55
-			newClusterSpec.Pod.ReadinessProbe.PeriodSeconds = 77
-			newClusterSpec.Pod.ReadinessProbe.SuccessThreshold = 80
-			newClusterSpec.Pod.ReadinessProbe.TimeoutSeconds = 4
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			newCluster.Spec.Pod.ReadinessProbe.FailureThreshold = 27
+			newCluster.Spec.Pod.ReadinessProbe.InitialDelaySeconds = 55
+			newCluster.Spec.Pod.ReadinessProbe.PeriodSeconds = 77
+			newCluster.Spec.Pod.ReadinessProbe.SuccessThreshold = 80
+			newCluster.Spec.Pod.ReadinessProbe.TimeoutSeconds = 4
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(1))
-			Expect(changes).To(HaveClusterChange(newClusterSpec.Racks[0],
+			Expect(changes).To(HaveClusterChange(newCluster.Spec.Racks[0],
 				UpdateRack, map[string]interface{}{
 					readinessProbeFailureThreshold:    float64(27),
 					readinessProbeInitialDelaySeconds: float64(55),
@@ -167,58 +171,58 @@ var _ = Describe("cluster events", func() {
 		})
 
 		It("should produce a patch containing the updated image when the bootstrapper image has been updated", func() {
-			newClusterSpec.Pod.BootstrapperImage = "someotherimage"
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			newCluster.Spec.Pod.BootstrapperImage = ptr.String("someotherimage")
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(1))
-			Expect(changes).To(HaveClusterChange(newClusterSpec.Racks[0], UpdateRack, map[string]interface{}{bootstrapperImage: "someotherimage"}, 0))
+			Expect(changes).To(HaveClusterChange(newCluster.Spec.Racks[0], UpdateRack, map[string]interface{}{bootstrapperImage: "someotherimage"}, 0))
 		})
 	})
 
 	Context("scale-up change is detected", func() {
 		Context("single-rack cluster", func() {
 			It("should produce a change with the updated number of replicas", func() {
-				newClusterSpec.Racks[0].Replicas = 2
-				changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+				newCluster.Spec.Racks[0].Replicas = 2
+				changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(changes).To(HaveLen(1))
-				Expect(changes).To(HaveClusterChange(newClusterSpec.Racks[0], UpdateRack, map[string]interface{}{rackReplicas: float64(2)}, 0))
+				Expect(changes).To(HaveClusterChange(newCluster.Spec.Racks[0], UpdateRack, map[string]interface{}{rackReplicas: float64(2)}, 0))
 			})
 		})
 
 		Context("multiple-rack cluster", func() {
 			It("should produce a change for each changed rack with the updated number of replicas", func() {
-				oldClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}, {Name: "b", Replicas: 1, StorageClass: "another-storage", Zone: "another-zone"}, {Name: "c", Replicas: 1, StorageClass: "yet-another-storage", Zone: "yet-another-zone"}}
-				newClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, StorageClass: "some-storage", Zone: "some-zone"}, {Name: "b", Replicas: 1, StorageClass: "another-storage", Zone: "another-zone"}, {Name: "c", Replicas: 3, StorageClass: "yet-another-storage", Zone: "yet-another-zone"}}
-				changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+				oldCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}, {Name: "b", Replicas: 1, StorageClass: "another-storage", Zone: "another-zone"}, {Name: "c", Replicas: 1, StorageClass: "yet-another-storage", Zone: "yet-another-zone"}}
+				newCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, StorageClass: "some-storage", Zone: "some-zone"}, {Name: "b", Replicas: 1, StorageClass: "another-storage", Zone: "another-zone"}, {Name: "c", Replicas: 3, StorageClass: "yet-another-storage", Zone: "yet-another-zone"}}
+				changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(changes).To(HaveLen(2))
-				Expect(changes).To(HaveClusterChange(newClusterSpec.Racks[0], UpdateRack, map[string]interface{}{rackReplicas: float64(2)}, 0))
-				Expect(changes).To(HaveClusterChange(newClusterSpec.Racks[2], UpdateRack, map[string]interface{}{rackReplicas: float64(3)}, 0))
+				Expect(changes).To(HaveClusterChange(newCluster.Spec.Racks[0], UpdateRack, map[string]interface{}{rackReplicas: float64(2)}, 0))
+				Expect(changes).To(HaveClusterChange(newCluster.Spec.Racks[2], UpdateRack, map[string]interface{}{rackReplicas: float64(3)}, 0))
 			})
 		})
 	})
 
 	Context("both pod resource and scale-up changes are detected", func() {
 		It("should produce a change for all racks with the updated pod resource and replication", func() {
-			oldClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}, {Name: "b", Replicas: 1, StorageClass: "another-storage", Zone: "another-zone"}}
-			newClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}, {Name: "b", Replicas: 3, StorageClass: "another-storage", Zone: "another-zone"}}
-			newClusterSpec.Pod.CPU = resource.MustParse("1")
-			newClusterSpec.Pod.Memory = resource.MustParse("999Mi")
+			oldCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}, {Name: "b", Replicas: 1, StorageClass: "another-storage", Zone: "another-zone"}}
+			newCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}, {Name: "b", Replicas: 3, StorageClass: "another-storage", Zone: "another-zone"}}
+			newCluster.Spec.Pod.CPU = resource.MustParse("1")
+			newCluster.Spec.Pod.Memory = resource.MustParse("999Mi")
 
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(2))
-			Expect(changes).To(HaveClusterChange(newClusterSpec.Racks[0], UpdateRack, map[string]interface{}{rackReplicas: float64(1), containerCPU: "1", containerMemoryRequest: "999Mi", containerMemoryLimit: "999Mi"}, 0))
-			Expect(changes).To(HaveClusterChange(newClusterSpec.Racks[1], UpdateRack, map[string]interface{}{rackReplicas: float64(3), containerCPU: "1", containerMemoryRequest: "999Mi", containerMemoryLimit: "999Mi"}, 0))
+			Expect(changes).To(HaveClusterChange(newCluster.Spec.Racks[0], UpdateRack, map[string]interface{}{rackReplicas: float64(1), containerCPU: "1", containerMemoryRequest: "999Mi", containerMemoryLimit: "999Mi"}, 0))
+			Expect(changes).To(HaveClusterChange(newCluster.Spec.Racks[1], UpdateRack, map[string]interface{}{rackReplicas: float64(3), containerCPU: "1", containerMemoryRequest: "999Mi", containerMemoryLimit: "999Mi"}, 0))
 		})
 	})
 
 	Context("nothing has changed in the definition", func() {
 		It("should not produce any changes", func() {
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(0))
 		})
@@ -226,53 +230,53 @@ var _ = Describe("cluster events", func() {
 
 	Context("unsupported property change is detected", func() {
 		It("should reject the change with an error message when DC is changed", func() {
-			newClusterSpec.Datacenter = ptr.String("other-dc")
-			_, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			newCluster.Spec.Datacenter = ptr.String("other-dc")
+			_, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).To(MatchError("changing dc is forbidden. The dc used will continue to be 'ADatacenter'"))
 		})
 
 		It("should report that the default DC name will continue to be used when no DC was previously provided", func() {
-			oldClusterSpec.Datacenter = nil
-			newClusterSpec.Datacenter = ptr.String("new-dc")
-			_, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			oldCluster.Spec.Datacenter = nil
+			newCluster.Spec.Datacenter = ptr.String("new-dc")
+			_, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).To(MatchError(fmt.Sprintf("changing dc is forbidden. The dc used will continue to be '%s'", v1alpha1.DefaultDCName)))
 		})
 
 		It("should reject the change with an error message when Image is changed", func() {
-			newClusterSpec.Pod.Image = "other-image"
-			_, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			newCluster.Spec.Pod.Image = "other-image"
+			_, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).To(MatchError("changing image is forbidden. The image used will continue to be 'anImage'"))
 		})
 
 		It("should report that the default image will continue to be used if an image was not previously specified", func() {
-			oldClusterSpec.Pod.Image = ""
-			newClusterSpec.Pod.Image = "other-image"
+			oldCluster.Spec.Pod.Image = ""
+			newCluster.Spec.Pod.Image = "other-image"
 
-			_, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			_, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).To(MatchError(fmt.Sprintf("changing image is forbidden. The image used will continue to be '%s'", cluster.DefaultCassandraImage)))
 		})
 
 		It("should reject the change with an error message when UseEmptyDir is changed", func() {
-			newClusterSpec.UseEmptyDir = ptr.Bool(true)
-			_, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			newCluster.Spec.UseEmptyDir = ptr.Bool(true)
+			_, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).To(MatchError("changing useEmptyDir is forbidden. The useEmptyDir used will continue to be 'false'"))
 		})
 
 		It("should reject the change with an error message when a rack storageClass is changed", func() {
-			newClusterSpec.Racks[0].StorageClass = "another-storage-class"
-			_, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			newCluster.Spec.Racks[0].StorageClass = "another-storage-class"
+			_, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).To(MatchError("changing storageClass for rack 'a' is forbidden. The storageClass used will continue to be 'some-storage'"))
 		})
 
 		It("should reject the change with an error message when a rack zone is changed", func() {
-			newClusterSpec.Racks[0].Zone = "another-zone"
-			_, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			newCluster.Spec.Racks[0].Zone = "another-zone"
+			_, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).To(MatchError("changing zone for rack 'a' is forbidden. The zone used will continue to be 'some-zone'"))
 		})
@@ -280,9 +284,9 @@ var _ = Describe("cluster events", func() {
 	Context("a new rack definition is added", func() {
 		It("should produce a change describing the new rack", func() {
 			newRack := v1alpha1.Rack{Name: "b", Replicas: 2, Zone: "zone-b", StorageClass: "storage-class-b"}
-			newClusterSpec.Racks = append(newClusterSpec.Racks, newRack)
+			newCluster.Spec.Racks = append(newCluster.Spec.Racks, newRack)
 
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(1))
 			Expect(changes).To(HaveClusterChange(newRack, AddRack, nil, 0))
@@ -291,45 +295,45 @@ var _ = Describe("cluster events", func() {
 
 	Context("a rack definition is deleted", func() {
 		BeforeEach(func() {
-			oldClusterSpec.Racks = []v1alpha1.Rack{
+			oldCluster.Spec.Racks = []v1alpha1.Rack{
 				{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"},
 				{Name: "b", Replicas: 1, Zone: "zone-b", StorageClass: "storage-class-b"},
 			}
 		})
 
 		It("should produce a change describing the rack which was deleted", func() {
-			newClusterSpec.Racks = []v1alpha1.Rack{{Name: "b", Replicas: 1, Zone: "zone-b", StorageClass: "storage-class-b"}}
+			newCluster.Spec.Racks = []v1alpha1.Rack{{Name: "b", Replicas: 1, Zone: "zone-b", StorageClass: "storage-class-b"}}
 
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(1))
-			Expect(changes).To(HaveClusterChange(oldClusterSpec.Racks[0], deleteRack, nil, 0))
+			Expect(changes).To(HaveClusterChange(oldCluster.Spec.Racks[0], deleteRack, nil, 0))
 		})
 	})
 
 	Context("a rack is scaled down", func() {
 		It("should produce a change describing the rack which was scaled down, and how many pods should be removed", func() {
-			oldClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, StorageClass: "some-storage", Zone: "some-zone"}}
-			newClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}}
+			oldCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, StorageClass: "some-storage", Zone: "some-zone"}}
+			newCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}}
 
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(1))
-			Expect(changes).To(HaveClusterChange(newClusterSpec.Racks[0], scaleDownRack, nil, 1))
+			Expect(changes).To(HaveClusterChange(newCluster.Spec.Racks[0], scaleDownRack, nil, 1))
 		})
 	})
 
 	Context("correct ordering of changes", func() {
 		It("should perform rack additions before rack deletions", func() {
-			oldClusterSpec.Racks = []v1alpha1.Rack{{Name: "c", Replicas: 1, Zone: "zone-c", StorageClass: "storage-class-c"}}
-			newClusterSpec.Racks = []v1alpha1.Rack{
+			oldCluster.Spec.Racks = []v1alpha1.Rack{{Name: "c", Replicas: 1, Zone: "zone-c", StorageClass: "storage-class-c"}}
+			newCluster.Spec.Racks = []v1alpha1.Rack{
 				{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"},
 				{Name: "b", Replicas: 1, Zone: "zone-b", StorageClass: "storage-class-b"},
 			}
 
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(3))
@@ -344,11 +348,11 @@ var _ = Describe("cluster events", func() {
 		})
 
 		It("should perform scale down operations before update operations", func() {
-			oldClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, Zone: "zone-a", StorageClass: "storage-class-a"}}
-			newClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}}
-			newClusterSpec.Pod.Memory = resource.MustParse("3Gi")
+			oldCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, Zone: "zone-a", StorageClass: "storage-class-a"}}
+			newCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}}
+			newCluster.Spec.Pod.Memory = resource.MustParse("3Gi")
 
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(2))
@@ -357,14 +361,14 @@ var _ = Describe("cluster events", func() {
 		})
 
 		It("should perform delete operations before scale down and update operations", func() {
-			oldClusterSpec.Racks = []v1alpha1.Rack{
+			oldCluster.Spec.Racks = []v1alpha1.Rack{
 				{Name: "a", Replicas: 2, Zone: "zone-a", StorageClass: "storage-class-a"},
 				{Name: "b", Replicas: 2, Zone: "zone-b", StorageClass: "storage-class-b"},
 			}
-			newClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}}
-			newClusterSpec.Pod.Memory = resource.MustParse("3Gi")
+			newCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}}
+			newCluster.Spec.Pod.Memory = resource.MustParse("3Gi")
 
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(3))
@@ -379,15 +383,15 @@ var _ = Describe("cluster events", func() {
 		})
 
 		It("should perform add operations before scale down and update operations", func() {
-			oldClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, Zone: "zone-a", StorageClass: "storage-class-a"}, {Name: "b", Replicas: 2, Zone: "zone-b", StorageClass: "storage-class-b"}}
-			newClusterSpec.Racks = []v1alpha1.Rack{
+			oldCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, Zone: "zone-a", StorageClass: "storage-class-a"}, {Name: "b", Replicas: 2, Zone: "zone-b", StorageClass: "storage-class-b"}}
+			newCluster.Spec.Racks = []v1alpha1.Rack{
 				{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"},
 				{Name: "b", Replicas: 1, Zone: "zone-b", StorageClass: "storage-class-b"},
 				{Name: "c", Replicas: 1, Zone: "zone-c", StorageClass: "storage-class-c"},
 			}
-			newClusterSpec.Pod.Memory = resource.MustParse("3Gi")
+			newCluster.Spec.Pod.Memory = resource.MustParse("3Gi")
 
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(5))
@@ -408,11 +412,11 @@ var _ = Describe("cluster events", func() {
 		})
 
 		It("should perform adds before delete, scale down and update operations", func() {
-			oldClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, Zone: "zone-a", StorageClass: "storage-class-a"}, {Name: "b", Replicas: 2, Zone: "zone-b", StorageClass: "storage-class-b"}}
-			newClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}, {Name: "c", Replicas: 1, Zone: "zone-c", StorageClass: "storage-class-c"}}
-			newClusterSpec.Pod.Memory = resource.MustParse("3Gi")
+			oldCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, Zone: "zone-a", StorageClass: "storage-class-a"}, {Name: "b", Replicas: 2, Zone: "zone-b", StorageClass: "storage-class-b"}}
+			newCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}, {Name: "c", Replicas: 1, Zone: "zone-c", StorageClass: "storage-class-c"}}
+			newCluster.Spec.Pod.Memory = resource.MustParse("3Gi")
 
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(4))
@@ -430,11 +434,11 @@ var _ = Describe("cluster events", func() {
 		})
 
 		It("should treat a scale up and update as a single update operation", func() {
-			oldClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}}
-			newClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, Zone: "zone-a", StorageClass: "storage-class-a"}}
-			newClusterSpec.Pod.Memory = resource.MustParse("3Gi")
+			oldCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}}
+			newCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 2, Zone: "zone-a", StorageClass: "storage-class-a"}}
+			newCluster.Spec.Pod.Memory = resource.MustParse("3Gi")
 
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(1))
@@ -443,11 +447,11 @@ var _ = Describe("cluster events", func() {
 		})
 
 		It("should order racks changes in the order in which the racks were defined in the old cluster state", func() {
-			oldClusterSpec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}, {Name: "b", Replicas: 1, Zone: "zone-b", StorageClass: "storage-class-b"}, {Name: "c", Replicas: 1, Zone: "zone-c", StorageClass: "storage-class-c"}}
-			newClusterSpec.Racks = []v1alpha1.Rack{{Name: "c", Replicas: 1, Zone: "zone-c", StorageClass: "storage-class-c"}, {Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}, {Name: "b", Replicas: 1, Zone: "zone-b", StorageClass: "storage-class-b"}}
-			newClusterSpec.Pod.CPU = resource.MustParse("101m")
+			oldCluster.Spec.Racks = []v1alpha1.Rack{{Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}, {Name: "b", Replicas: 1, Zone: "zone-b", StorageClass: "storage-class-b"}, {Name: "c", Replicas: 1, Zone: "zone-c", StorageClass: "storage-class-c"}}
+			newCluster.Spec.Racks = []v1alpha1.Rack{{Name: "c", Replicas: 1, Zone: "zone-c", StorageClass: "storage-class-c"}, {Name: "a", Replicas: 1, Zone: "zone-a", StorageClass: "storage-class-a"}, {Name: "b", Replicas: 1, Zone: "zone-b", StorageClass: "storage-class-b"}}
+			newCluster.Spec.Pod.CPU = resource.MustParse("101m")
 
-			changes, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
+			changes, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(changes).To(HaveLen(3))

--- a/cassandra-operator/pkg/operator/operations/adjuster/adjuster_test.go
+++ b/cassandra-operator/pkg/operator/operations/adjuster/adjuster_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1"
-	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/cluster"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/util/ptr"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -67,7 +66,7 @@ var _ = Describe("cluster events", func() {
 				Datacenter: ptr.String("ADatacenter"),
 				Racks:      []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}},
 				Pod: v1alpha1.Pod{
-					Image:          "anImage",
+					Image:          ptr.String("anImage"),
 					Memory:         resource.MustParse("2Gi"),
 					CPU:            resource.MustParse("100m"),
 					StorageSize:    resource.MustParse("1Gi"),
@@ -81,7 +80,7 @@ var _ = Describe("cluster events", func() {
 				Datacenter: ptr.String("ADatacenter"),
 				Racks:      []v1alpha1.Rack{{Name: "a", Replicas: 1, StorageClass: "some-storage", Zone: "some-zone"}},
 				Pod: v1alpha1.Pod{
-					Image:          "anImage",
+					Image:          ptr.String("anImage"),
 					Memory:         resource.MustParse("2Gi"),
 					CPU:            resource.MustParse("100m"),
 					StorageSize:    resource.MustParse("1Gi"),
@@ -245,19 +244,19 @@ var _ = Describe("cluster events", func() {
 		})
 
 		It("should reject the change with an error message when Image is changed", func() {
-			newCluster.Spec.Pod.Image = "other-image"
+			newCluster.Spec.Pod.Image = ptr.String("other-image")
 			_, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
 			Expect(err).To(MatchError("changing image is forbidden. The image used will continue to be 'anImage'"))
 		})
 
 		It("should report that the default image will continue to be used if an image was not previously specified", func() {
-			oldCluster.Spec.Pod.Image = ""
-			newCluster.Spec.Pod.Image = "other-image"
+			oldCluster.Spec.Pod.Image = nil
+			newCluster.Spec.Pod.Image = ptr.String("other-image")
 
 			_, err := adjuster.ChangesForCluster(oldCluster, newCluster)
 
-			Expect(err).To(MatchError(fmt.Sprintf("changing image is forbidden. The image used will continue to be '%s'", cluster.DefaultCassandraImage)))
+			Expect(err).To(MatchError(fmt.Sprintf("changing image is forbidden. The image used will continue to be '%s'", v1alpha1.DefaultCassandraImage)))
 		})
 
 		It("should reject the change with an error message when UseEmptyDir is changed", func() {

--- a/cassandra-operator/pkg/operator/operations/adjuster/adjuster_test.go
+++ b/cassandra-operator/pkg/operator/operations/adjuster/adjuster_test.go
@@ -257,7 +257,7 @@ var _ = Describe("cluster events", func() {
 		})
 
 		It("should reject the change with an error message when UseEmptyDir is changed", func() {
-			newClusterSpec.UseEmptyDir = true
+			newClusterSpec.UseEmptyDir = ptr.Bool(true)
 			_, err := adjuster.ChangesForCluster(oldClusterSpec, newClusterSpec)
 
 			Expect(err).To(MatchError("changing useEmptyDir is forbidden. The useEmptyDir used will continue to be 'false'"))

--- a/cassandra-operator/pkg/operator/operations/update_cluster.go
+++ b/cassandra-operator/pkg/operator/operations/update_cluster.go
@@ -30,7 +30,7 @@ func (o *UpdateClusterOperation) Execute() {
 		return
 	}
 
-	clusterChanges, err := o.adjuster.ChangesForCluster(&oldCluster.Spec, &newCluster.Spec)
+	clusterChanges, err := o.adjuster.ChangesForCluster(oldCluster, newCluster)
 	if err != nil {
 		o.eventRecorder.Eventf(oldCluster, v1.EventTypeWarning, cluster.InvalidChangeEvent, "unable to generate patch for cluster %s.%s: %v", newCluster.Namespace, newCluster.Name, err)
 		return

--- a/cassandra-operator/pkg/operator/operator.go
+++ b/cassandra-operator/pkg/operator/operator.go
@@ -13,11 +13,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1"
+	v1alpha1helpers "github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1/helpers"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/client/clientset/versioned"
 	informers "github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/client/informers/externalversions"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/cluster"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/dispatcher"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/metrics"
+	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/util/ptr"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
@@ -184,9 +186,9 @@ func (o *Operator) clusterUpdated(old interface{}, new interface{}) {
 }
 
 func (o *Operator) adjustUseEmptyDir(cluster *v1alpha1.Cassandra) {
-	if cluster.Spec.UseEmptyDir && !o.config.AllowEmptyDir {
+	if v1alpha1helpers.UseEmptyDir(cluster) && !o.config.AllowEmptyDir {
 		log.Warnf("Cluster %s.%s cannot be configured to use emptyDir, as the operator is configured not to allow the creation of clusters which use emptyDir storage.", cluster.Namespace, cluster.Name)
-		cluster.Spec.UseEmptyDir = false
+		cluster.Spec.UseEmptyDir = ptr.Bool(false)
 	}
 }
 

--- a/cassandra-operator/test/e2e/cluster_setup.go
+++ b/cassandra-operator/test/e2e/cluster_setup.go
@@ -68,7 +68,7 @@ func clusterDefaultSpec() *v1alpha1.CassandraSpec {
 		UseEmptyDir: ptr.Bool(false),
 		Pod: v1alpha1.Pod{
 			BootstrapperImage: &CassandraBootstrapperImageName,
-			Image:             CassandraImageName,
+			Image:             &CassandraImageName,
 			Memory:            resource.MustParse(PodMemory),
 			CPU:               resource.MustParse(PodCPU),
 			StorageSize:       resource.MustParse(podStorageSize),

--- a/cassandra-operator/test/e2e/cluster_setup.go
+++ b/cassandra-operator/test/e2e/cluster_setup.go
@@ -67,7 +67,7 @@ func clusterDefaultSpec() *v1alpha1.CassandraSpec {
 		Racks:       []v1alpha1.Rack{},
 		UseEmptyDir: ptr.Bool(false),
 		Pod: v1alpha1.Pod{
-			BootstrapperImage: CassandraBootstrapperImageName,
+			BootstrapperImage: &CassandraBootstrapperImageName,
 			Image:             CassandraImageName,
 			Memory:            resource.MustParse(PodMemory),
 			CPU:               resource.MustParse(PodCPU),

--- a/cassandra-operator/test/e2e/cluster_setup.go
+++ b/cassandra-operator/test/e2e/cluster_setup.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/cluster"
+	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/util/ptr"
 	"io/ioutil"
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -64,7 +65,7 @@ func SnapshotSchedule(cron string) *v1alpha1.Snapshot {
 func clusterDefaultSpec() *v1alpha1.CassandraSpec {
 	return &v1alpha1.CassandraSpec{
 		Racks:       []v1alpha1.Rack{},
-		UseEmptyDir: false,
+		UseEmptyDir: ptr.Bool(false),
 		Pod: v1alpha1.Pod{
 			BootstrapperImage: CassandraBootstrapperImageName,
 			Image:             CassandraImageName,

--- a/cassandra-operator/test/e2e/cluster_setup.go
+++ b/cassandra-operator/test/e2e/cluster_setup.go
@@ -57,7 +57,7 @@ func Rack(rackName string, replicas int32) v1alpha1.Rack {
 
 func SnapshotSchedule(cron string) *v1alpha1.Snapshot {
 	return &v1alpha1.Snapshot{
-		Image:    CassandraSnapshotImageName,
+		Image:    &CassandraSnapshotImageName,
 		Schedule: cron,
 	}
 }

--- a/cassandra-operator/test/e2e/parallel/creation/creation_test.go
+++ b/cassandra-operator/test/e2e/parallel/creation/creation_test.go
@@ -46,7 +46,7 @@ func createClustersInParallel(multipleRacksCluster, emptyDirCluster *TestCluster
 	AClusterWithName(multipleRacksCluster.Name).AndClusterSpec(&v1alpha1.CassandraSpec{
 		Datacenter: ptr.String("custom-dc"),
 		Pod: v1alpha1.Pod{
-			BootstrapperImage: CassandraBootstrapperImageName,
+			BootstrapperImage: &CassandraBootstrapperImageName,
 			Image:             CassandraImageName,
 			Memory:            resource.MustParse("987Mi"),
 			CPU:               resource.MustParse("1m"),

--- a/cassandra-operator/test/e2e/parallel/creation/creation_test.go
+++ b/cassandra-operator/test/e2e/parallel/creation/creation_test.go
@@ -47,7 +47,7 @@ func createClustersInParallel(multipleRacksCluster, emptyDirCluster *TestCluster
 		Datacenter: ptr.String("custom-dc"),
 		Pod: v1alpha1.Pod{
 			BootstrapperImage: &CassandraBootstrapperImageName,
-			Image:             CassandraImageName,
+			Image:             &CassandraImageName,
 			Memory:            resource.MustParse("987Mi"),
 			CPU:               resource.MustParse("1m"),
 			StorageSize:       resource.MustParse("100Mi"),

--- a/cassandra-operator/test/e2e/parallel/modification/modification_test.go
+++ b/cassandra-operator/test/e2e/parallel/modification/modification_test.go
@@ -79,7 +79,7 @@ var _ = Context("Allowable cluster modifications", func() {
 		// when
 		revisionsBeforeUpdate := statefulSetRevisions(clusterName, racks)
 		TheClusterPodSpecAreChangedTo(Namespace, clusterName, v1alpha1.Pod{
-			BootstrapperImage: CassandraBootstrapperImageName,
+			BootstrapperImage: &CassandraBootstrapperImageName,
 			Image:             CassandraImageName,
 			Memory:            resource.MustParse("999Mi"),
 			CPU:               resource.MustParse("1m"),

--- a/cassandra-operator/test/e2e/parallel/modification/modification_test.go
+++ b/cassandra-operator/test/e2e/parallel/modification/modification_test.go
@@ -80,7 +80,7 @@ var _ = Context("Allowable cluster modifications", func() {
 		revisionsBeforeUpdate := statefulSetRevisions(clusterName, racks)
 		TheClusterPodSpecAreChangedTo(Namespace, clusterName, v1alpha1.Pod{
 			BootstrapperImage: &CassandraBootstrapperImageName,
-			Image:             CassandraImageName,
+			Image:             &CassandraImageName,
 			Memory:            resource.MustParse("999Mi"),
 			CPU:               resource.MustParse("1m"),
 			LivenessProbe: &v1alpha1.Probe{

--- a/cassandra-operator/test/e2e/parallel/snapshot/snapshot_test.go
+++ b/cassandra-operator/test/e2e/parallel/snapshot/snapshot_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Cassandra snapshot scheduling", func() {
 			AClusterWithName(clusterName).
 				AndRacks([]v1alpha1.Rack{Rack("a", 1)}).
 				AndScheduledSnapshot(&v1alpha1.Snapshot{
-					Image:     CassandraSnapshotImageName,
+					Image:     &CassandraSnapshotImageName,
 					Schedule:  "59 23 * * *",
 					Keyspaces: []string{"keyspace1", "keyspace3"},
 					RetentionPolicy: &v1alpha1.RetentionPolicy{
@@ -142,7 +142,7 @@ var _ = Describe("Cassandra snapshot scheduling", func() {
 			clusterModifiedTime := time.Now()
 			snapshotTimeout := int32(5)
 			AScheduledSnapshotIsAddedToCluster(Namespace, clusterName, &v1alpha1.Snapshot{
-				Image:          CassandraSnapshotImageName,
+				Image:          &CassandraSnapshotImageName,
 				Schedule:       "1 23 * * *",
 				TimeoutSeconds: &snapshotTimeout,
 				Keyspaces:      []string{"k1", "k2"},
@@ -182,7 +182,7 @@ var _ = Describe("Cassandra snapshot scheduling", func() {
 			AClusterWithName(clusterName).
 				AndRacks([]v1alpha1.Rack{Rack("a", 1)}).
 				AndScheduledSnapshot(&v1alpha1.Snapshot{
-					Image:     CassandraSnapshotImageName,
+					Image:     &CassandraSnapshotImageName,
 					Schedule:  "59 23 * * *",
 					Keyspaces: []string{"keyspace1", "keyspace3"},
 					RetentionPolicy: &v1alpha1.RetentionPolicy{
@@ -227,7 +227,7 @@ var _ = Describe("Cassandra snapshot scheduling", func() {
 			AClusterWithName(clusterName).
 				AndRacks([]v1alpha1.Rack{Rack("a", 1)}).
 				AndScheduledSnapshot(&v1alpha1.Snapshot{
-					Image:     CassandraSnapshotImageName,
+					Image:     &CassandraSnapshotImageName,
 					Schedule:  "59 23 * * *",
 					Keyspaces: []string{"keyspace1", "keyspace3"},
 					RetentionPolicy: &v1alpha1.RetentionPolicy{
@@ -243,7 +243,7 @@ var _ = Describe("Cassandra snapshot scheduling", func() {
 			// when
 			snapshotModificationTime := time.Now()
 			AScheduledSnapshotIsChangedForCluster(Namespace, clusterName, &v1alpha1.Snapshot{
-				Image:     CassandraSnapshotImageName,
+				Image:     &CassandraSnapshotImageName,
 				Schedule:  "15 9 * * *",
 				Keyspaces: []string{"k2"},
 				RetentionPolicy: &v1alpha1.RetentionPolicy{

--- a/cassandra-operator/test/e2e/steps.go
+++ b/cassandra-operator/test/e2e/steps.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1"
+	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/util/ptr"
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *ClusterBuilder) IsDefined() {
 
 	if c.useEmptyDir {
 		c.clusterSpec.Pod.StorageSize = resource.MustParse("0")
-		c.clusterSpec.UseEmptyDir = true
+		c.clusterSpec.UseEmptyDir = ptr.Bool(true)
 	}
 
 	if !c.withoutCustomConfig {

--- a/cassandra-operator/test/e2e/steps.go
+++ b/cassandra-operator/test/e2e/steps.go
@@ -107,7 +107,7 @@ func TheClusterPodSpecAreChangedTo(namespace, clusterName string, podSpec v1alph
 
 func TheImageImmutablePropertyIsChangedTo(namespace, clusterName, imageName string) {
 	mutateCassandraSpec(namespace, clusterName, func(spec *v1alpha1.CassandraSpec) {
-		spec.Pod.Image = imageName
+		spec.Pod.Image = &imageName
 	})
 	log.Infof("Updated pod image for cluster %s", clusterName)
 }

--- a/cassandra-operator/test/e2e/test_environment.go
+++ b/cassandra-operator/test/e2e/test_environment.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
+	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/cluster"
 	"os"
 	"time"
@@ -98,7 +99,7 @@ func init() {
 		CassandraReadinessProbeFailureThreshold = 8 // allow 2mins
 	}
 
-	CassandraBootstrapperImageName = getEnvOrDefault("CASSANDRA_BOOTSTRAPPER_IMAGE", cluster.DefaultCassandraBootstrapperImage)
+	CassandraBootstrapperImageName = getEnvOrDefault("CASSANDRA_BOOTSTRAPPER_IMAGE", v1alpha1.DefaultCassandraBootstrapperImage)
 	CassandraSnapshotImageName = getEnvOrDefault("CASSANDRA_SNAPSHOT_IMAGE", cluster.DefaultCassandraSnapshotImage)
 
 	Namespace = os.Getenv("NAMESPACE")

--- a/cassandra-operator/test/e2e/test_environment.go
+++ b/cassandra-operator/test/e2e/test_environment.go
@@ -91,7 +91,7 @@ func init() {
 		CassandraLivenessProbeFailureThreshold = 3
 		CassandraReadinessProbeFailureThreshold = 3
 	} else {
-		CassandraImageName = cluster.DefaultCassandraImage
+		CassandraImageName = v1alpha1.DefaultCassandraImage
 		CassandraInitialDelay = 30
 		CassandraLivenessPeriod = 30
 		CassandraReadinessPeriod = 15

--- a/cassandra-operator/test/e2e/test_environment.go
+++ b/cassandra-operator/test/e2e/test_environment.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1"
-	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/cluster"
 	"os"
 	"time"
 
@@ -100,7 +99,7 @@ func init() {
 	}
 
 	CassandraBootstrapperImageName = getEnvOrDefault("CASSANDRA_BOOTSTRAPPER_IMAGE", v1alpha1.DefaultCassandraBootstrapperImage)
-	CassandraSnapshotImageName = getEnvOrDefault("CASSANDRA_SNAPSHOT_IMAGE", cluster.DefaultCassandraSnapshotImage)
+	CassandraSnapshotImageName = getEnvOrDefault("CASSANDRA_SNAPSHOT_IMAGE", v1alpha1.DefaultCassandraSnapshotImage)
 
 	Namespace = os.Getenv("NAMESPACE")
 	if Namespace == "" {


### PR DESCRIPTION
A series of patches to move optional API fields to use pointers.

Part of #33.