### PR TITLE
Fake Cassandra Jolokia responses

### DIFF
--- a/fake-cassandra-docker/Makefile
+++ b/fake-cassandra-docker/Makefile
@@ -31,7 +31,7 @@ push-image: docker-image common-docker-push
 
 dgoss:
 	@echo "== dgoss"
-	dgoss run $(dockerTestImage)
+	dgoss run --env "NODE_LISTEN_ADDRESS=192.0.2.100" $(dockerTestImage)
 
 clean: common-docker-clean
 	@echo "== clean"

--- a/fake-cassandra-docker/goss.yaml
+++ b/fake-cassandra-docker/goss.yaml
@@ -21,15 +21,29 @@ http:
   "http://localhost:7777/jolokia/read/java.lang:type=Memory/HeapMemoryUsage":
     status: 200
     body: ["status\":403"]
-  "http://localhost:7777/jolokia/exec/org.apache.cassandra.db:type=EndpointSnitchInfo/getRack/localhost":
+  "http://localhost:7777/jolokia/exec/org.apache.cassandra.db:type=EndpointSnitchInfo/getRack/192.0.2.100":
     status: 200
-    body: ["status\":200"]
+    body: ['status":200']
   "http://localhost:7777/jolokia/exec/org.apache.cassandra.db:type=EndpointSnitchInfo/getDatacenter/localhost":
     status: 200
     body: ["status\":403"]
-  "http://localhost:7777/jolokia/read/org.apache.cassandra.db:type=StorageService/LiveNodes,UnreachableNodes,JoiningNodes,LeavingNodes,MovingNodes":
+  "http://localhost:7777/jolokia/read/org.apache.cassandra.db:type=StorageService/LiveNodes":
     status: 200
-    body: ["status\":200"]
+    body:
+      - '"status":200'
+      - '"value":["192.0.2.100"]'
+  "http://localhost:7777/jolokia/read/org.apache.cassandra.db:type=StorageService/UnreachableNodes":
+    status: 200
+    body: ['status":200']
+  "http://localhost:7777/jolokia/read/org.apache.cassandra.db:type=StorageService/JoiningNodes":
+    status: 200
+    body: ['status":200']
+  "http://localhost:7777/jolokia/read/org.apache.cassandra.db:type=StorageService/LeavingNodes":
+    status: 200
+    body: ['status":200']
+  "http://localhost:7777/jolokia/read/org.apache.cassandra.db:type=StorageService/MovingNodes":
+    status: 200
+    body: ['status":200']
   "http://localhost:7777/jolokia/read/org.apache.cassandra.db:type=StorageService/ClusterName":
     status: 200
     body: ["status\":403"]

--- a/fake-cassandra-docker/src/main/java/com/sky/core/operators/fake/FakeCassandra.java
+++ b/fake-cassandra-docker/src/main/java/com/sky/core/operators/fake/FakeCassandra.java
@@ -9,16 +9,22 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class FakeCassandra {
     private static final int[] DUMMY_PORTS = new int[]{7000, 7199, 9042};
+    public static String nodeListenAddress;
 
     public static void main(String[] args) {
+        nodeListenAddress = System.getenv("NODE_LISTEN_ADDRESS");
+        if (nodeListenAddress == null) {
+            nodeListenAddress = "127.0.0.1";
+        }
+
         final FakeCassandra fc = new FakeCassandra();
         try {
             fc.run();
@@ -106,12 +112,22 @@ class FakeMetricsServer extends NanoHTTPD {
 }
 
 class FakeJolokiaServer extends NanoHTTPD {
-
-    private static final Set<String> PERMITTED_PATHS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            "/jolokia/exec/org.apache.cassandra.db:type=EndpointSnitchInfo/getRack/localhost",
-            "/jolokia/read/org.apache.cassandra.db:type=StorageService/LiveNodes,UnreachableNodes,JoiningNodes,LeavingNodes,MovingNodes"
-    )));
-
+    private static Map<String, String> PERMITTED_PATHS;
+    static {
+        PERMITTED_PATHS = new HashMap<>();
+        PERMITTED_PATHS.put("/jolokia/exec/org.apache.cassandra.db:type=EndpointSnitchInfo/getRack/" + FakeCassandra.nodeListenAddress,
+                            "{\"status\":200}");
+        PERMITTED_PATHS.put("/jolokia/read/org.apache.cassandra.db:type=StorageService/LiveNodes",
+                            "{\"status\":200, \"value\":[\"" + FakeCassandra.nodeListenAddress+ "\"]}");
+        PERMITTED_PATHS.put("/jolokia/read/org.apache.cassandra.db:type=StorageService/UnreachableNodes",
+                            "{\"status\":200}");
+        PERMITTED_PATHS.put("/jolokia/read/org.apache.cassandra.db:type=StorageService/JoiningNodes",
+                            "{\"status\":200}");
+        PERMITTED_PATHS.put("/jolokia/read/org.apache.cassandra.db:type=StorageService/LeavingNodes",
+                            "{\"status\":200}");
+        PERMITTED_PATHS.put("/jolokia/read/org.apache.cassandra.db:type=StorageService/MovingNodes",
+                            "{\"status\":200}");
+    }
     public FakeJolokiaServer() {
         super(7777);
     }
@@ -120,8 +136,8 @@ class FakeJolokiaServer extends NanoHTTPD {
     public Response serve(final IHTTPSession session) {
         if (session.getMethod() == Method.POST) {
             return newFixedLengthResponse(Response.Status.FORBIDDEN, "application/text", "HTTP method post is not allowed according to the installed security policy\",\"status\":403");
-        } else if(PERMITTED_PATHS.contains(session.getUri())) {
-            return newFixedLengthResponse("status\":200");
+        } else if(PERMITTED_PATHS.containsKey(session.getUri())) {
+            return newFixedLengthResponse(PERMITTED_PATHS.get(session.getUri()));
         } else {
             return newFixedLengthResponse("status\":403");
         }


### PR DESCRIPTION
Required for: #98 

This makes the fake-cassandra-docker container respond with more realistic Jolokia responses.
Enough to make the metrics client code think that the local node is UP and NORMAL.
