### PR TITLE
Add caching of gradle dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,10 @@ jobs:
             # assumes this stage is only included on the correct branch or tag
             all_branches: true
 
-# See https://docs.travis-ci.com/user/languages/java/#caching
+# Cache dependencies for Java and Golang
+# See:
+# * https://docs.travis-ci.com/user/languages/java/#caching
+# * https://restic.net/blog/2018-09-02/travis-build-cache
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -93,3 +96,5 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+    - $HOME/.cache/go-build
+    - $HOME/gopath/pkg/mod

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ jobs:
             # assumes this stage is only included on the correct branch or tag
             all_branches: true
 
-# Cache dependencies for Java and Golang
+# Cache dependencies for Java and Golang.
 # See:
 # * https://docs.travis-ci.com/user/languages/java/#caching
 # * https://restic.net/blog/2018-09-02/travis-build-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,3 +84,12 @@ jobs:
           on:
             # assumes this stage is only included on the correct branch or tag
             all_branches: true
+
+# See https://docs.travis-ci.com/user/languages/java/#caching
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
Fixes: #141 

I'm assuming that #141 is caused by  some sort of rate limit.
 * https://travis-ci.community/t/continuous-maven-repo-403/3908/2

Perhaps this caching will reduce the number of requests we make to `repo.maven.apache.org`

See https://docs.travis-ci.com/user/languages/java/#caching

