### PR TITLE
Remove app label references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.82.0-alpha
+
+- [BUGFIX] [Remove app label references](#230) (@chuckydev)
+
 ## 0.81.0-alpha
 
 - [ENHANCEMENT] [Improve robustness of E2E tests](#224) (@alangibson01)

--- a/cassandra-operator/pkg/metrics/metrics_test.go
+++ b/cassandra-operator/pkg/metrics/metrics_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/cluster"
+	pkgcluster "github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/cluster"
 	metricstesting "github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/metrics/testing"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/test/stub"
 )
@@ -20,7 +21,7 @@ var _ = Describe("Cluster Metrics", func() {
 	var (
 		jolokiaURLProvider *metricstesting.StubbedJolokiaURLProvider
 		metricsGatherer    Gatherer
-		cluster            *cluster.Cluster
+		cluster            *pkgcluster.Cluster
 	)
 
 	BeforeEach(func() {
@@ -161,13 +162,12 @@ var _ = Describe("Cluster Metrics", func() {
 })
 
 var _ = Describe("Metrics URL randomisation", func() {
-	var cluster *cluster.Cluster
+	var cluster *pkgcluster.Cluster
 	var standardPodLabels map[string]string
 
 	BeforeEach(func() {
 		cluster = aCluster("testcluster", "test")
-		standardPodLabels = make(map[string]string)
-		standardPodLabels["app.kubernetes.io/instance"] = "testcluster"
+		standardPodLabels = map[string]string{pkgcluster.ApplicationInstanceLabel: "testcluster"}
 	})
 
 	It("should return a different pod URL each time it is invoked", func() {
@@ -405,7 +405,7 @@ func (jh *jolokiaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func aCluster(clusterName, namespace string) *cluster.Cluster {
+func aCluster(clusterName, namespace string) *pkgcluster.Cluster {
 	clusterDef := apis.ACassandra().WithDefaults().WithName(clusterName).WithNamespace(namespace).Build()
 	return cluster.New(clusterDef)
 }

--- a/cassandra-operator/pkg/metrics/prometheus.go
+++ b/cassandra-operator/pkg/metrics/prometheus.go
@@ -12,7 +12,7 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreV1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/cluster"
+	pkgcluster "github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/cluster"
 )
 
 type clusterMetrics struct {
@@ -73,7 +73,7 @@ func NewMetrics(podsGetter coreV1.PodsGetter, config *Config) *PrometheusMetrics
 }
 
 // DeleteMetrics stops reporting metrics for the given cluster
-func (m *PrometheusMetrics) DeleteMetrics(cluster *cluster.Cluster) {
+func (m *PrometheusMetrics) DeleteMetrics(cluster *pkgcluster.Cluster) {
 	if !m.clustersMetrics.clusterSizeGauge.Delete(map[string]string{"cluster": cluster.Name(), "namespace": cluster.Namespace()}) {
 		log.Warnf("Unable to delete cluster_size metrics for cluster %s", cluster.QualifiedName())
 	}
@@ -91,7 +91,7 @@ func (m *PrometheusMetrics) DeleteMetrics(cluster *cluster.Cluster) {
 }
 
 // RemoveNodeFromMetrics stops reporting metrics for the given node
-func (m *PrometheusMetrics) RemoveNodeFromMetrics(cluster *cluster.Cluster, podName, rackName string) {
+func (m *PrometheusMetrics) RemoveNodeFromMetrics(cluster *pkgcluster.Cluster, podName, rackName string) {
 	log.Infof("Removing node cluster:%s, pod:%s, rack:%s from metrics", cluster.QualifiedName(), podName, rackName)
 	for _, labelPair := range allLabelPairs {
 		deleted := m.clustersMetrics.cassandraNodeStatusGauge.Delete(map[string]string{
@@ -109,7 +109,7 @@ func (m *PrometheusMetrics) RemoveNodeFromMetrics(cluster *cluster.Cluster, podN
 }
 
 // UpdateMetrics updates metrics for the given cluster
-func (m *PrometheusMetrics) UpdateMetrics(cluster *cluster.Cluster) {
+func (m *PrometheusMetrics) UpdateMetrics(cluster *pkgcluster.Cluster) {
 	podIPMapper, err := m.podsInCluster(cluster)
 	if err != nil {
 		log.Errorf("Unable to retrieve pod list for cluster %s: %v", cluster.QualifiedName(), err)
@@ -141,7 +141,7 @@ func (m *PrometheusMetrics) UpdateMetrics(cluster *cluster.Cluster) {
 	m.clustersMetrics.clusterSizeGauge.WithLabelValues(cluster.Name(), cluster.Namespace()).Set(clusterLastKnownTopology.nodeCount())
 }
 
-func (m *PrometheusMetrics) updateNodeStatus(cluster *cluster.Cluster, rack string, podName string, nodeStatus *nodeStatus) {
+func (m *PrometheusMetrics) updateNodeStatus(cluster *pkgcluster.Cluster, rack string, podName string, nodeStatus *nodeStatus) {
 	m.clustersMetrics.cassandraNodeStatusGauge.WithLabelValues(cluster.Name(), cluster.Namespace(), rack, podName, nodeStatus.livenessLabel(), nodeStatus.stateLabel()).Set(1)
 	for _, ul := range nodeStatus.unapplicableLabelPairs() {
 		m.clustersMetrics.cassandraNodeStatusGauge.WithLabelValues(cluster.Name(), cluster.Namespace(), rack, podName, ul.liveness, ul.state).Set(0)
@@ -167,7 +167,7 @@ func registerMetrics() *clusterMetrics {
 	return &clusterMetrics{cassandraNodeStatusGauge: cassandraNodeStatusGauge, clusterSizeGauge: clusterSizeGauge}
 }
 
-func (m *PrometheusMetrics) podsInCluster(cluster *cluster.Cluster) (*podIPMapper, error) {
+func (m *PrometheusMetrics) podsInCluster(cluster *pkgcluster.Cluster) (*podIPMapper, error) {
 	podList, err := m.podsGetter.Pods(cluster.Namespace()).List(metaV1.ListOptions{LabelSelector: cluster.CassandraPodSelector()})
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve pods for cluster %s, %v", cluster.QualifiedName(), err)
@@ -181,7 +181,7 @@ func (m *PrometheusMetrics) podsInCluster(cluster *cluster.Cluster) (*podIPMappe
 }
 
 type podIPMapper struct {
-	cluster     *cluster.Cluster
+	cluster     *pkgcluster.Cluster
 	podIPToName map[string]string
 }
 
@@ -194,7 +194,7 @@ func (p *podIPMapper) withPodNameDoOrError(podIP string, action func(string)) {
 	}
 }
 
-func (u *randomisingJolokiaURLProvider) URLFor(cluster *cluster.Cluster) string {
+func (u *randomisingJolokiaURLProvider) URLFor(cluster *pkgcluster.Cluster) string {
 	var jolokiaHostname string
 	podsWithIPAddresses, err := u.podsWithIPAddresses(cluster)
 
@@ -211,8 +211,8 @@ func (u *randomisingJolokiaURLProvider) URLFor(cluster *cluster.Cluster) string 
 	return fmt.Sprintf("http://%s:7777", jolokiaHostname)
 }
 
-func (u *randomisingJolokiaURLProvider) podsWithIPAddresses(cluster *cluster.Cluster) ([]v1.Pod, error) {
-	podList, err := u.podsGetter.Pods(cluster.Namespace()).List(metaV1.ListOptions{LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=%s", cluster.Name())})
+func (u *randomisingJolokiaURLProvider) podsWithIPAddresses(cluster *pkgcluster.Cluster) ([]v1.Pod, error) {
+	podList, err := u.podsGetter.Pods(cluster.Namespace()).List(metaV1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", pkgcluster.ApplicationInstanceLabel, cluster.Name())})
 	if err != nil {
 		return nil, err
 	}

--- a/cassandra-operator/pkg/metrics/prometheus.go
+++ b/cassandra-operator/pkg/metrics/prometheus.go
@@ -212,7 +212,7 @@ func (u *randomisingJolokiaURLProvider) URLFor(cluster *cluster.Cluster) string 
 }
 
 func (u *randomisingJolokiaURLProvider) podsWithIPAddresses(cluster *cluster.Cluster) ([]v1.Pod, error) {
-	podList, err := u.podsGetter.Pods(cluster.Namespace()).List(metaV1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", cluster.Name())})
+	podList, err := u.podsGetter.Pods(cluster.Namespace()).List(metaV1.ListOptions{LabelSelector: fmt.Sprintf("app.kubernetes.io/instance=%s", cluster.Name())})
 	if err != nil {
 		return nil, err
 	}

--- a/cassandra-operator/test/e2e/cluster_status.go
+++ b/cassandra-operator/test/e2e/cluster_status.go
@@ -2,19 +2,20 @@ package e2e
 
 import (
 	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/apis/cassandra/v1alpha1"
 	"github.com/sky-uk/cassandra-operator/cassandra-operator/pkg/cluster"
-	"io/ioutil"
 	appsV1 "k8s.io/api/apps/v1beta2"
 	"k8s.io/api/batch/v1beta1"
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"regexp"
-	"strings"
-	"time"
 )
 
 func PersistentVolumeClaimsForCluster(namespace, clusterName string) func() ([]*kubernetesResource, error) {
@@ -208,7 +209,7 @@ func PodCreationTime(namespace, podName string) func() (time.Time, error) {
 
 func PodRestartForCluster(namespace, clusterName string) func() (int, error) {
 	return func() (int, error) {
-		pods, err := KubeClientset.CoreV1().Pods(namespace).List(metaV1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", clusterName)})
+		pods, err := KubeClientset.CoreV1().Pods(namespace).List(metaV1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", cluster.ApplicationInstanceLabel, clusterName)})
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
Required by https://github.com/sky-uk/cassandra-operator/issues/231

Originally the operator was using the `app` label in In order to obtain the IP of each cassandra pod. Thas has since been removed and has caused a bug which defaults the lookup to only fetch from a single pod.

A simple fix for this is to instead lookup using a different label which will always be present. This PR opts for the Application Instance label that defaults to the cluster name.

I have also added a unit test that explicitly checks for the specific label in the podGetter stub.