### PR TITLE
Test running tests on separate machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,17 @@ jobs:
     - stage: test
       name: cassandra-operator
       before_script: make setup install kind
-      script: make -C cassandra-operator check
+      script: SKIP_PACKAGES=modification make -C cassandra-operator deploy-operator e2e-test
+
+    - stage: test
+      name: cassandra-operator-modification
+      before_script: make setup install kind
+      script: E2E_TEST=modification make -C cassandra-operator deploy-operator e2e-test-parallel
+
+    - stage: test
+      name: cassandra-operator-integration
+      before_script: make setup install kind
+      script: make -C cassandra-operator test deploy-operator integration-test
 
     - stage: test
       name: cassandra-bootstrapper

--- a/cassandra-operator/Makefile
+++ b/cassandra-operator/Makefile
@@ -91,7 +91,7 @@ ensure-test-report-dir-exists: ensure-build-dir-exists
 
 test: ensure-test-report-dir-exists
 	@echo "== test"
-	ginkgo $(GINKGO_PARALLEL_OPTIONS) -r -skipPackage=$(SKIP_PACKAGES) -compilers=$(GINKGO_COMPILERS) --v --progress pkg cmd -- -junit-report-dir $(junitReportDir)
+	ginkgo -r -skipPackage=$(SKIP_PACKAGES) -compilers=$(GINKGO_COMPILERS) --v --progress pkg cmd -- -junit-report-dir $(junitReportDir)
 
 integration-test: ensure-test-report-dir-exists
 	@echo "== integration-test"


### PR DESCRIPTION
Running the cassandra-operator travis job is taking over 30 minutes at present and that will only get longer as more tests are added.

Splitting the job in to 3 and running in parallel will reduce the end to end time by about a third.