### PR TITLE
Reduced creation CPU request

### DIFF
--- a/cassandra-operator/test/e2e/parallel/creation/creation_test.go
+++ b/cassandra-operator/test/e2e/parallel/creation/creation_test.go
@@ -87,7 +87,7 @@ func createClustersInParallel(multipleRacksCluster, emptyDirCluster *TestCluster
 					Resources: coreV1.ResourceRequirements{
 						Requests: coreV1.ResourceList{
 							coreV1.ResourceMemory: resource.MustParse("50Mi"),
-							coreV1.ResourceCPU:    resource.MustParse("50m"),
+							coreV1.ResourceCPU:    resource.MustParse("0m"),
 						},
 						Limits: coreV1.ResourceList{
 							coreV1.ResourceMemory: resource.MustParse("50Mi"),
@@ -173,7 +173,7 @@ var _ = Context("When a cluster doesn't already exist", func() {
 				ContainerName: "cassandra-sidecar",
 				MemoryRequest: ptr.String("50Mi"),
 				MemoryLimit:   ptr.String("50Mi"),
-				CPURequest:    ptr.String("50m"),
+				CPURequest:    ptr.String("0"),
 				CPULimit:      nil,
 			})),
 		))

--- a/cassandra-operator/test/e2e/parallel/modification/sidecar_external_modifiation_test.go
+++ b/cassandra-operator/test/e2e/parallel/modification/sidecar_external_modifiation_test.go
@@ -106,7 +106,7 @@ var _ = Context("External sidecar statefulset modifications", func() {
 		//when
 		By("Modifying resource fields directly in the rack statefulset resource")
 		modifiedMemory := "60Mi"
-		modifiedCPU := "50m"
+		modifiedCPU := "1m"
 		editedResources := &coreV1.ResourceRequirements{
 			Requests: coreV1.ResourceList{
 				coreV1.ResourceMemory: resource.MustParse(modifiedMemory),

--- a/cassandra-operator/test/e2e/test_environment.go
+++ b/cassandra-operator/test/e2e/test_environment.go
@@ -44,7 +44,7 @@ var (
 	NodeRestartDuration                     time.Duration
 	NodeTerminationDuration                 time.Duration
 	Namespace                               string
-	MaxCassandraNodesPerNamespace			int
+	MaxCassandraNodesPerNamespace           int
 )
 
 func init() {


### PR DESCRIPTION
Currently the sidecar modification tests are requesting unnecessary amounts of cpu. I have defaulted the requested to 0 and altered the modified to use 1m.