### PR TITLE
Upgrade to go 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: go
 sudo: required
 
 go:
-  - 1.12
+  - 1.15
 
 services:
   - docker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ All new code, including changes to existing code, should be tested and have a co
 
 The following must be installed on your development machine:
 
-- `go` (>=1.12)
+- `go` (>=1.15)
 - `docker`
 - `jdk-11` or above
 - `gcc` (or `build-essential` package on debian distributions)

--- a/cassandra-operator/go.mod
+++ b/cassandra-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/sky-uk/cassandra-operator/cassandra-operator
 
-go 1.12
+go 1.15
 
 require (
 	github.com/PaesslerAG/gval v0.1.1 // indirect

--- a/cassandra-operator/hack/update-codegen.sh
+++ b/cassandra-operator/hack/update-codegen.sh
@@ -33,7 +33,5 @@ ${codeGenDir}/generate-groups.sh all \
   --go-header-file ${scriptDir}/empty-boilerplate.txt \
   --output-base ${tempDir}
 
-
 cp "${tempDir}/${basePackage}/${generateDeepCopy}" "${projectDir}/${generateDeepCopy}"
 cp -ur "${tempDir}/${basePackage}/${pkgClientPath}" "${projectDir}/pkg/"
-

--- a/cassandra-operator/hack/update-codegen.sh
+++ b/cassandra-operator/hack/update-codegen.sh
@@ -9,9 +9,16 @@ projectDir="${scriptDir}/.."
 codeGenDir="${projectDir}/vendor/k8s.io/code-generator"
 basePackage="github.com/sky-uk/cassandra-operator/cassandra-operator"
 groupVersion="cassandra:v1alpha1"
-VENDOR_DIR="${projectDir}/vendor"
-GEN_FILE_PATH="/pkg/apis/cassandra/v1alpha1/zz_generated.deepcopy.go"
-CLIENT_PATH="/pkg/client"
+tempDir="$(mktemp -d)"
+generateDeepCopy="/pkg/apis/cassandra/v1alpha1/zz_generated.deepcopy.go"
+pkgClientPath="/pkg/client"
+
+cleanup() {
+  rm -rf "${tempDir}"
+}
+trap "cleanup" EXIT SIGINT
+
+mkdir -p "${tempDir}/${basePackage}}"
 
 # ensure code-generator is available in vendor directory
 # https://github.com/kubernetes/code-generator/issues/57#issuecomment-498310800
@@ -24,9 +31,9 @@ ${codeGenDir}/generate-groups.sh all \
   ${basePackage}/pkg/client ${basePackage}/pkg/apis \
   ${groupVersion} \
   --go-header-file ${scriptDir}/empty-boilerplate.txt \
-  --output-base ${VENDOR_DIR}
+  --output-base ${tempDir}
 
 
-cp "${VENDOR_DIR}/${basePackage}/${GEN_FILE_PATH}" "${projectDir}/${GEN_FILE_PATH}"
-cp -ur "${VENDOR_DIR}/${basePackage}/${CLIENT_PATH}" "${projectDir}/pkg/"
+cp "${tempDir}/${basePackage}/${generateDeepCopy}" "${projectDir}/${generateDeepCopy}"
+cp -ur "${tempDir}/${basePackage}/${pkgClientPath}" "${projectDir}/pkg/"
 

--- a/cassandra-operator/pkg/apis/cassandra/v1alpha1/validation/cassandra_test.go
+++ b/cassandra-operator/pkg/apis/cassandra/v1alpha1/validation/cassandra_test.go
@@ -874,7 +874,7 @@ var _ = Describe("ValidateCassandraUpdate", func() {
 			func(c *v1alpha1.Cassandra) {
 				c.Spec.Pod.Env = &[]v1alpha1.CassEnvVar{
 					v1alpha1.CassEnvVar{
-						Name:  "defaultEnvName",
+						Name: "defaultEnvName",
 						ValueFrom: &v1alpha1.CassEnvVarSource{
 							SecretKeyRef: coreV1.SecretKeySelector{
 								Key: "someKey",
@@ -974,7 +974,7 @@ var _ = Describe("ValidateCassandraUpdate", func() {
 			func(c *v1alpha1.Cassandra) {
 				c.Spec.Pod.Env = &[]v1alpha1.CassEnvVar{
 					v1alpha1.CassEnvVar{
-						Name:  "EXTRA_CLASSPATH",
+						Name: "EXTRA_CLASSPATH",
 						ValueFrom: &v1alpha1.CassEnvVarSource{
 							SecretKeyRef: coreV1.SecretKeySelector{
 								Key: "aKey",

--- a/cassandra-operator/pkg/cluster/cluster.go
+++ b/cassandra-operator/pkg/cluster/cluster.go
@@ -432,7 +432,7 @@ func (c *Cluster) createContainerEnvVars() []v1.EnvVar {
 		return []v1.EnvVar{getExtraClassPathVar()}
 	}
 	numOfReservedVariablesToBeAdded := 1 // Only EXTRA_CLASSPATH at this stage
-	containerEnvVars := make([]v1.EnvVar, len(*c.definition.Spec.Pod.Env) + numOfReservedVariablesToBeAdded)
+	containerEnvVars := make([]v1.EnvVar, len(*c.definition.Spec.Pod.Env)+numOfReservedVariablesToBeAdded)
 
 	i := 0
 	for _, cassEnvVar := range *c.definition.Spec.Pod.Env {

--- a/cassandra-operator/pkg/cluster/clusterstate_test.go
+++ b/cassandra-operator/pkg/cluster/clusterstate_test.go
@@ -27,7 +27,7 @@ var _ = Describe("the cluster state reconstruction", func() {
 		expectedCassandra    *v1alpha1.Cassandra
 		stateFinder          currentClusterStateFinder
 		fakes                *mocks
-		mockedStatefulSets    *v1beta2.StatefulSetList
+		mockedStatefulSets   *v1beta2.StatefulSetList
 	)
 
 	BeforeEach(func() {

--- a/cassandra-sidecar/go.mod
+++ b/cassandra-sidecar/go.mod
@@ -1,6 +1,6 @@
 module github.com/sky-uk/cassandra-operator/cassandra-sidecar
 
-go 1.12
+go 1.15
 
 require (
 	github.com/onsi/ginkgo v1.8.0

--- a/cassandra-snapshot/go.mod
+++ b/cassandra-snapshot/go.mod
@@ -1,6 +1,6 @@
 module github.com/sky-uk/cassandra-operator/cassandra-snapshot
 
-go 1.12
+go 1.15
 
 require (
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect


### PR DESCRIPTION
This was a lot simpler than I thought it would be.

The only real issue is that using the "hack" [described here](https://github.com/sky-uk/cassandra-operator/pull/250#issuecomment-770716692) here will no longer work so I have implemented the alternative approach on that issue for staging the generated code in a temp dir.