### PR TITLE
Add longer wait time for test in remote clusters

### DIFF
--- a/cassandra-operator/test/e2e/sequential/invalid_modification/invalid_modification_test.go
+++ b/cassandra-operator/test/e2e/sequential/invalid_modification/invalid_modification_test.go
@@ -144,7 +144,7 @@ var _ = Context("forbidden cluster modifications", func() {
 		// then
 		By("recording a warning event about the forbidden change")
 
-		Eventually(CassandraEventsFor(Namespace, multipleNodeCluster.Name), EventPublicationTimeout, CheckInterval).Should(HaveEvent(EventExpectation{
+		Eventually(CassandraEventsFor(Namespace, multipleNodeCluster.Name), 90*time.Second, CheckInterval).Should(HaveEvent(EventExpectation{
 			Type:                 coreV1.EventTypeWarning,
 			Reason:               cluster.InvalidChangeEvent,
 			Message:              "spec.Pod.Env: Forbidden: spec.Pod.env cannot contain reserved variable with Name: EXTRA_CLASSPATH",


### PR DESCRIPTION
On remotely deployed clusters (as opposed to kind clusters deployed on the same host) we have observed test failures waiting for the events to propagate. This allows a little more time in the test expectation.